### PR TITLE
Parallel fast bail-out; argument norm to flat array.

### DIFF
--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -5,14 +5,16 @@ var util = require('./util');
 
 function parallel(middlewares) {
 
+	middlewares = util.normalizeMiddlewareList(arguments);
 	util.checkMiddlewareList(middlewares);
 
 	return function run(req, res, next) {
 		// Count how many middlewares there are.
-		var remaining = middlewares.length;
+		var remaining = middlewares.length, done = false;
 		// Called after each middleware has run.
 		function ran(err) {
-			if (err || --remaining <= 0) {
+			if (!done && (err || --remaining <= 0)) {
+				done = true;
 				next(err);
 			}
 		}

--- a/lib/serial.js
+++ b/lib/serial.js
@@ -5,6 +5,7 @@ var util = require('./util');
 
 function serial(middlewares) {
 
+	middlewares = util.normalizeMiddlewareList(arguments);
 	util.checkMiddlewareList(middlewares);
 
 	return function dispatch(req, res, next) {

--- a/lib/util.js
+++ b/lib/util.js
@@ -17,8 +17,13 @@ function checkMiddlewareList(list) {
 	}
 }
 
+function normalizeMiddlewareList(list) {
+	return _.flatten(list);
+}
+
 module.exports = {
 	isMiddleware: isMiddleware,
 	isMiddlewareList: isMiddlewareList,
-	checkMiddlewareList: checkMiddlewareList
+	checkMiddlewareList: checkMiddlewareList,
+	normalizeMiddlewareList: normalizeMiddlewareList
 };

--- a/test/spec/util.spec.js
+++ b/test/spec/util.spec.js
@@ -50,4 +50,14 @@ describe('util', function() {
 			util.checkMiddlewareList([fn1, fn2]);
 		});
 	});
+
+	describe('.normalizeMiddlewareList', function() {
+		it('should mash arguments to single array', function() {
+			function check() {
+				return util.normalizeMiddlewareList(arguments);
+			}
+
+			expect(check(fn1, [fn2, fn3])).to.deep.equal([fn1, fn2, fn3]);
+		});
+	});
 });


### PR DESCRIPTION
The `parallel` middleware now handles multiple errors being fired and only triggers the first one.

Arguments can now be passed in similar to how `express` does with all arguments and nested arrays being flattened into a single array.
