### PR TITLE
Add `series` alias to `serial`.

### DIFF
--- a/lib/async.js
+++ b/lib/async.js
@@ -3,5 +3,6 @@
 
 module.exports = {
 	serial: require('./serial'),
+	series: require('./serial'),
 	parallel: require('./parallel')
 };


### PR DESCRIPTION
This more closely matches the `async` library's API.
