### PR TITLE
Optimize single entries in `series` and `parallel`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+sudo: false
 language: node_js
 node_js:
 - '0.11'

--- a/lib/parallel.js
+++ b/lib/parallel.js
@@ -8,6 +8,10 @@ function parallel(middlewares) {
 	middlewares = util.normalizeMiddlewareList(arguments);
 	util.checkMiddlewareList(middlewares);
 
+	if (middlewares.length === 1) {
+		return middlewares[0];
+	}
+
 	return function run(req, res, next) {
 		// Count how many middlewares there are.
 		var remaining = middlewares.length, done = false;

--- a/lib/serial.js
+++ b/lib/serial.js
@@ -8,6 +8,10 @@ function serial(middlewares) {
 	middlewares = util.normalizeMiddlewareList(arguments);
 	util.checkMiddlewareList(middlewares);
 
+	if (middlewares.length === 1) {
+		return middlewares[0];
+	}
+
 	return function dispatch(req, res, next) {
 		function handle(i) {
 			if (i >= middlewares.length) {


### PR DESCRIPTION
When there's only one entry to either the function `series` or `parallel` no action need be taken since only the original middleware should be run. This is a bit of a microoptimization that pevents a couple of unnecessary function calls. A case for the 0-length middleware list could also be an option.
